### PR TITLE
Add smart detection of free spaces to belt splitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I had to write a documentation for the school project. It goes more in depth int
 
 [Dokumentation.pdf](https://github.com/user-attachments/files/20745087/Dokumentation.pdf)
 
-But be aware that it is already outdated.
+But be aware that the description of the algorithm is already outdated.
 
 ## License
 

--- a/src/content/machine_types.rs
+++ b/src/content/machine_types.rs
@@ -414,11 +414,19 @@ impl PreferredItemsSide {
     }
 }
 
+impl Default for PreferredItemsSide {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(unused)]
 pub trait UnwrapOutputItems {
     fn unwrap_single_side(&self) -> &VecDeque<Item>;
     fn unwrap_multiple_sides(&self) -> &PreferredItemsSide;
 }
 
+#[allow(unused)]
 pub trait UnwrapOutputItemsMut {
     fn unwrap_single_side_mut(&mut self) -> &mut VecDeque<Item>;
     fn unwrap_multiple_sides_mut(&mut self) -> &mut PreferredItemsSide;

--- a/src/content/machines/belt.rs
+++ b/src/content/machines/belt.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     content::{
         items::ItemType,
-        machine_types::{InputItems, MachineType, OutputItems, Side},
+        machine_types::{
+            InputItems, MachineType, OutputItems, Side, UnwrapOutputItems, UnwrapOutputItemsMut,
+        },
     },
     plugins::world::MiddlegroundObject,
 };
@@ -16,13 +18,13 @@ impl MachineType for Belt {
     fn perform_action(
         &mut self,
         input_items: &mut InputItems,
-        output_items: &mut OutputItems,
+        mut output_items: Option<&mut OutputItems>,
         _middleground_object: Option<MiddlegroundObject>,
     ) {
-        if output_items.exactly_one().is_empty()
+        if output_items.unwrap_single_side().is_empty()
             && let Some(input_item) = input_items.exactly_one_mut().pop_front()
         {
-            output_items.exactly_one_mut().push_back(input_item);
+            output_items.unwrap_single_side_mut().push_back(input_item);
         }
     }
 
@@ -30,10 +32,10 @@ impl MachineType for Belt {
         &self,
         _item: &ItemType,
         input_items: &InputItems,
-        output_items: &OutputItems,
+        output_items: Option<&OutputItems>,
         _input_side: &Side,
     ) -> bool {
-        (input_items.exactly_one().len() + output_items.exactly_one().len()) == 0
+        (input_items.exactly_one().len() + output_items.unwrap_single_side().len()) == 0
     }
 
     fn tick_after_first(&self) -> bool {

--- a/src/content/machines/combiner.rs
+++ b/src/content/machines/combiner.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     content::{
         items::ItemType,
-        machine_types::{InputItems, MachineType, OutputItems, Side},
+        machine_types::{
+            InputItems, MachineType, OutputItems, Side, UnwrapOutputItems, UnwrapOutputItemsMut,
+        },
     },
     plugins::world::MiddlegroundObject,
 };
@@ -28,7 +30,7 @@ impl MachineType for Combiner {
     fn perform_action(
         &mut self,
         input_items: &mut InputItems,
-        output_items: &mut OutputItems,
+        mut output_items: Option<&mut OutputItems>,
         _middleground_object: Option<MiddlegroundObject>,
     ) {
         // Get current input side
@@ -41,7 +43,7 @@ impl MachineType for Combiner {
         let current_input_side = self.input_sides[current_input_side_index];
 
         // Check if there are any items on the combiner
-        if output_items.exactly_one().is_empty()
+        if output_items.unwrap_single_side().is_empty()
             && let Some(input_item) = input_items
                 .get_side_mut(&current_input_side)
                 .as_mut()
@@ -50,7 +52,7 @@ impl MachineType for Combiner {
                 })
                 .pop_front()
         {
-            output_items.exactly_one_mut().push_back(input_item);
+            output_items.unwrap_single_side_mut().push_back(input_item);
         }
 
         self.last_input_side_index = current_input_side_index;
@@ -60,11 +62,16 @@ impl MachineType for Combiner {
         &self,
         _item: &ItemType,
         input_items: &InputItems,
-        output_items: &OutputItems,
+        output_items: Option<&OutputItems>,
         input_side: &Side,
     ) -> bool {
         // Only one item is allowed in the combiner
-        if input_items.count() + output_items.count() > 0 {
+        if input_items.count()
+            + output_items
+                .expect("Combiner should have output items")
+                .len()
+            > 0
+        {
             return false;
         }
 

--- a/src/content/machines/crafter.rs
+++ b/src/content/machines/crafter.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     content::{
         items::ItemType,
-        machine_types::{InputItems, MachineType, OutputItems, Side},
+        machine_types::{
+            InputItems, MachineType, OutputItems, Side, UnwrapOutputItems, UnwrapOutputItemsMut,
+        },
     },
     plugins::{crafting::recipe_types::CrafterRecipe, world::MiddlegroundObject},
 };
@@ -33,7 +35,7 @@ impl MachineType for Crafter {
     fn perform_action(
         &mut self,
         input_items: &mut InputItems,
-        output_items: &mut OutputItems,
+        mut output_items: Option<&mut OutputItems>,
         _middleground_object: Option<MiddlegroundObject>,
     ) {
         // Crafting
@@ -53,7 +55,7 @@ impl MachineType for Crafter {
 
                 for _ in 0..*output_count {
                     output_items
-                        .exactly_one_mut()
+                        .unwrap_single_side_mut()
                         .push_back((*output_item).into());
                 }
 
@@ -66,7 +68,7 @@ impl MachineType for Crafter {
 
             None => {
                 // Only try to craft something, if there are no items already crafted
-                if !output_items.is_empty() {
+                if !output_items.unwrap_single_side().is_empty() {
                     return;
                 }
 
@@ -109,7 +111,7 @@ impl MachineType for Crafter {
         &self,
         item: &ItemType,
         input_items: &InputItems,
-        _output_items: &OutputItems,
+        _output_items: Option<&OutputItems>,
         _input_side: &Side,
     ) -> bool {
         input_items.count_item(item) < 50

--- a/src/content/machines/miner.rs
+++ b/src/content/machines/miner.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     content::{
         items::ItemType,
-        machine_types::{InputItems, MachineType, OutputItems, Side},
+        machine_types::{
+            InputItems, MachineType, OutputItems, Side, UnwrapOutputItems, UnwrapOutputItemsMut,
+        },
     },
     plugins::world::MiddlegroundObject,
 };
@@ -27,12 +29,12 @@ impl MachineType for Miner {
     fn perform_action(
         &mut self,
         _input_items: &mut InputItems,
-        output_items: &mut OutputItems,
+        mut output_items: Option<&mut OutputItems>,
         middleground_object: Option<MiddlegroundObject>,
     ) {
         // Mining
 
-        if output_items.exactly_one().len() < 50
+        if output_items.unwrap_single_side().len() < 50
             && let Some(middleground_object) = middleground_object
         {
             match &mut self.mining_time {
@@ -44,7 +46,7 @@ impl MachineType for Miner {
                     };
 
                     // Append the resource under the miner
-                    output_items.exactly_one_mut().push_back(item.into());
+                    output_items.unwrap_single_side_mut().push_back(item.into());
 
                     self.mining_time = None;
                 }
@@ -53,7 +55,7 @@ impl MachineType for Miner {
                     *mining_time -= 1;
                 }
                 // If there are no other items in the output, reset the timer
-                None if output_items.is_empty() => {
+                None if output_items.unwrap_single_side().is_empty() => {
                     self.mining_time = Some(Self::MINING_TIME);
                 }
                 // else do nothing and try again next time
@@ -66,7 +68,7 @@ impl MachineType for Miner {
         &self,
         _item: &ItemType,
         _input_items: &InputItems,
-        _output_items: &OutputItems,
+        _output_items: Option<&OutputItems>,
         _input_side: &Side,
     ) -> bool {
         unreachable!()

--- a/src/content/machines/splitter.rs
+++ b/src/content/machines/splitter.rs
@@ -1,9 +1,10 @@
+use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     content::{
         items::ItemType,
-        machine_types::{InputItems, MachineType, OutputItems, Side},
+        machine_types::{InputItems, MachineType, OutputItems, Side, UnwrapOutputItemsMut},
     },
     plugins::world::MiddlegroundObject,
 };
@@ -28,9 +29,11 @@ impl MachineType for Splitter {
     fn perform_action(
         &mut self,
         input_items: &mut InputItems,
-        output_items: &mut OutputItems,
+        mut output_items: Option<&mut OutputItems>,
         _middleground_object: Option<MiddlegroundObject>,
     ) {
+        info!("{output_items:?}");
+
         // Get current input side
         let current_output_side_index = match self.last_output_side_index {
             0 => 1,
@@ -41,17 +44,23 @@ impl MachineType for Splitter {
         let current_output_side = self.output_sides[current_output_side_index];
 
         //  Check if there are any items in the output and if something can be pulled from the input
-        if output_items.is_empty()
+        if output_items
+            .as_ref()
+            .expect("Splitter should have output sides")
+            .is_empty()
             && let Some(input_item) = input_items.exactly_one_mut().pop_front()
         {
-            output_items
-                .get_side_mut(&current_output_side)
-                .as_mut()
-                .unwrap_or_else(|| {
-                    panic!("Splitter should have the output side `{current_output_side:?}`")
-                })
-                .push_back(input_item);
+            // Get output_items (it should always be multiples sides)
+            let output_items = output_items.unwrap_multiple_sides_mut();
+            // Push item
+            output_items.items.push_back(input_item);
 
+            // Set the preferred sides
+            output_items.preferred_sides.clear();
+            output_items.push_side(current_output_side);
+            output_items.push_side(self.output_sides[self.last_output_side_index]);
+
+            // Switch last output side
             self.last_output_side_index = current_output_side_index;
         }
     }
@@ -60,10 +69,14 @@ impl MachineType for Splitter {
         &self,
         _item: &ItemType,
         input_items: &InputItems,
-        output_items: &OutputItems,
+        output_items: Option<&OutputItems>,
         _input_side: &Side,
     ) -> bool {
-        input_items.count() + output_items.count() < 1
+        input_items.count()
+            + output_items
+                .expect("Splitter should have output items")
+                .len()
+            < 1
     }
 
     fn tick_after_first(&self) -> bool {

--- a/src/content/machines/splitter.rs
+++ b/src/content/machines/splitter.rs
@@ -1,4 +1,3 @@
-use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/src/content/machines/splitter.rs
+++ b/src/content/machines/splitter.rs
@@ -32,8 +32,6 @@ impl MachineType for Splitter {
         mut output_items: Option<&mut OutputItems>,
         _middleground_object: Option<MiddlegroundObject>,
     ) {
-        info!("{output_items:?}");
-
         // Get current input side
         let current_output_side_index = match self.last_output_side_index {
             0 => 1,

--- a/src/content/machines/void.rs
+++ b/src/content/machines/void.rs
@@ -16,7 +16,7 @@ impl MachineType for Void {
     fn perform_action(
         &mut self,
         input_items: &mut InputItems,
-        _output_items: &mut OutputItems,
+        _output_items: Option<&mut OutputItems>,
         _middleground_object: Option<MiddlegroundObject>,
     ) {
         input_items.all().clear();
@@ -26,7 +26,7 @@ impl MachineType for Void {
         &self,
         _item: &ItemType,
         _input_items: &InputItems,
-        _output_items: &OutputItems,
+        _output_items: Option<&OutputItems>,
         _input_side: &Side,
     ) -> bool {
         true

--- a/src/game_save_types.rs
+++ b/src/game_save_types.rs
@@ -40,5 +40,5 @@ pub type MachineTiles = Vec<(
     ForegroundObject,
     Box<dyn MachineType>,
     InputItems,
-    OutputItems,
+    Option<OutputItems>,
 )>;

--- a/src/plugins/building/place_buildings.rs
+++ b/src/plugins/building/place_buildings.rs
@@ -122,7 +122,7 @@ pub fn place_buildings(
                         None => return,
                     },
                     foreground_object.get_input_sides().into(),
-                    foreground_object.get_output_sides().into(),
+                    foreground_object.get_output_sides().try_into().ok(),
                 ),
                 BuildingInput(foreground_object.get_input_sides()),
                 BuildingOutput(foreground_object.get_output_sides()),

--- a/src/plugins/rendering/belt.rs
+++ b/src/plugins/rendering/belt.rs
@@ -50,7 +50,10 @@ pub fn update_item_tilemap(
             // `input_items` and `output_items` together should only have one
 
             let mut all_items = machine.input_items.all();
-            all_items.extend(&machine.output_items.all());
+
+            if let Some(output_items) = &machine.output_items {
+                all_items.extend(output_items.get_items());
+            }
 
             match all_items.front() {
                 None => {}

--- a/src/plugins/simulation/simulate.rs
+++ b/src/plugins/simulation/simulate.rs
@@ -5,10 +5,7 @@ use bevy_ecs_tilemap::tiles::{TilePos, TileTextureIndex};
 use petgraph::{algo::tarjan_scc, prelude::*};
 
 use crate::{
-    content::{
-        machine_types::{OutputItems, Side},
-        machines::combiner::Combiner,
-    },
+    content::machine_types::{OutputItems, Side},
     plugins::world::{Middleground, MiddlegroundObject},
 };
 
@@ -25,46 +22,15 @@ pub fn simulate(
     }
 
     let mut made_progress = true;
-    let mut is_first_time_ticking = true;
+    let mut first_time_ticking = true;
 
     // Do this until everything that can be moved is moved
     while made_progress {
-        // Thas variable tracks whether anything has changed in this iteration
         made_progress = false;
 
         // Get all the SCCs (Strongly Connected Components) using Tarjan's algorithm
         // This function also performs a topological sort on the result
-        let tarjan_sccs = tarjan_scc(&**simulation_graph);
-        let mut scc = Vec::new();
-
-        // Then split them again at combiners
-        for component in &tarjan_sccs {
-            let mut splits = Vec::new();
-
-            for (index, node_index) in component.iter().enumerate() {
-                let (machine, _) = &simulation_graph[*node_index];
-
-                if machine
-                    .machine_type
-                    .as_ref()
-                    .as_any()
-                    .downcast_ref::<Combiner>()
-                    .is_some()
-                    && index != 0
-                {
-                    splits.push(index - 1);
-                }
-            }
-
-            let mut previous = 0;
-
-            for split_index in splits {
-                scc.push(&component[previous..split_index]);
-                previous = split_index;
-            }
-
-            scc.push(&component[previous..]);
-        }
+        let scc = tarjan_scc(&**simulation_graph);
 
         let mut visited = HashSet::new();
         let mut times_machines_hit: HashMap<NodeIndex, u32> = HashMap::new();
@@ -139,12 +105,10 @@ pub fn simulate(
                             visited.insert(node_index);
 
                             // Perform the machine's action
-                            if machine.machine_type.tick_after_first() || is_first_time_ticking {
-                                machine.perform_action(get_middleground_object(
-                                    &tile_query,
-                                    machine_tile_pos,
-                                ));
-                            }
+                            machine.perform_action(get_middleground_object(
+                                &tile_query,
+                                machine_tile_pos,
+                            ));
                         }
 
                         let Some(mut output_items) = machine.output_items.as_mut() else {
@@ -276,7 +240,7 @@ pub fn simulate(
                     visited.insert(node_index);
                     let (machine, machine_tile_pos) = &mut simulation_graph[node_index];
 
-                    if machine.machine_type.tick_after_first() || is_first_time_ticking {
+                    if machine.machine_type.tick_after_first() || first_time_ticking {
                         // Perform the machine's action
                         machine
                             .perform_action(get_middleground_object(&tile_query, machine_tile_pos));
@@ -285,7 +249,7 @@ pub fn simulate(
             }
         }
 
-        is_first_time_ticking = false;
+        first_time_ticking = false;
     }
 
     // reset the has_moved flag


### PR DESCRIPTION
Splitters will now skip occupied or missing outputs so they won't back everything up.

Closes #116 